### PR TITLE
Fix duplicated id after removing a car and adding another one

### DIFF
--- a/hotwheels-api/routes/cars.js
+++ b/hotwheels-api/routes/cars.js
@@ -37,7 +37,8 @@ router.post('/', (req, res) => {
       const cars = JSON.parse(data); // Transforma o conteúdo em um objeto JavaScript
       const newCar = req.body; // Obtém o novo objeto de carro a partir do corpo da requisição
 
-      const newId = cars.length + 1;
+      const carsLength = cars.length;
+      const newId = carsLength ? cars[carsLength -1].id + 1 : 1;
       // Adiciona o novo carro ao array de carros
       cars.push({ id: newId, ...newCar });
 


### PR DESCRIPTION
How to reproduce: delete a car `DELETE` endpoint and add another one using `POST`
Solution: use the number of the last  available id + 1